### PR TITLE
perf: refresh faker instance to clear memory

### DIFF
--- a/src/Console/Commands/ObfuscateDatabaseCommand.php
+++ b/src/Console/Commands/ObfuscateDatabaseCommand.php
@@ -191,29 +191,26 @@ class ObfuscateDatabaseCommand extends Command
 
                 // Process in smaller batches to reduce memory usage
                 if (count($updates) >= $batchSize) {
-                    DB::table($tableName)->upsert($updates, $primaryColumns, array_keys($fields));
+                    DB::table($tableName)->upsert($updates, $primaryColumns);
                     $progress->advance($processedCount);
 
                     $updates = [];
                     $processedCount = 0;
                     unset($update);
                 }
-
-                unset($record);
             }
 
             // Process any remaining updates
             if (count($updates) > 0) {
-                DB::table($tableName)->upsert($updates, $primaryColumns, array_keys($fields));
+                DB::table($tableName)->upsert($updates, $primaryColumns);
                 $progress->advance($processedCount);
                 unset($update);
             }
-
-            unset($records);
-        });
+        }, $primaryColumns[0]);
 
         $progress->finish();
 
         $this->obfuscatorInstances = [];
+        FakerObfuscator::refreshFakerInstance();
     }
 }

--- a/src/Obfuscators/FakerObfuscator.php
+++ b/src/Obfuscators/FakerObfuscator.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace Intermax\Blur\Obfuscators;
 
+use Faker;
 use Faker\Generator;
 use Intermax\Blur\Contracts\Obfuscator;
 use InvalidArgumentException;
 
 class FakerObfuscator implements Obfuscator
 {
-    private Generator $faker;
+    private static ?Generator $faker = null;
 
     public function __construct()
     {
-        // Create a single Faker instance to reuse
-        $this->faker = fake();
+        if (self::$faker === null) {
+            self::refreshFakerInstance();
+        }
     }
 
     /**
@@ -27,6 +29,11 @@ class FakerObfuscator implements Obfuscator
             throw new InvalidArgumentException('No faker method provided');
         }
 
-        return $this->faker->{$parameters[0]}();
+        return self::$faker->{$parameters[0]}();
+    }
+
+    public static function refreshFakerInstance(): void
+    {
+        self::$faker = Faker\Factory::create();
     }
 }


### PR DESCRIPTION
`fake()` is bound as a singleton to the container so refreshing by calling `fake()` again doesn't actually use a new instance.